### PR TITLE
Add Emotion and styled-jsx to list of allowed CSS-in-JS libs?

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The language choices are English, French, German, Japanese, Chinese, Korean, and
   - Node.js v8+
   - NPM or Yarn
   - React v16+
-  - Styled components, LESS, SCSS, or Stylus
+  - Styled components, Emotion, styled-jsx, LESS, SCSS, or Stylus
   - MongoDB
 - **You must not** use the following third-party libraries:
   - Any public web UI frameworks, for example, [Bootstrap](http://getbootstrap.com/), [Semantic UI](http://semantic-ui.com/), [Material UI](https://material-ui.com/), or [Ant Design](https://ant.design/) -- you may borrow the design, but you have to come up with your own style sheets. However, you will not be judged by the appearance of your web.


### PR DESCRIPTION
Rationale:

- Emotion is getting ever more popular. It is very similar to styled-components.
- styled-jsx is used in Next.js projects. It also provides good encapsulation of stylesheets.