### PR TITLE
Add a criteria about following Node.js production practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ You will be judged by the following criteria.
 - Functionality is correct with respect to the specifications.
 - Good security principles are followed.
 - Good software engineering principles are followed, for example, [SOLID principles](https://en.wikipedia.org/wiki/SOLID).
+- The backend code follows Joyent’s [Node.js production practices](https://www.joyent.com/node-js/production), especially when it comes to [error handling](https://www.joyent.com/node-js/production/design/errors).
 - Identifiers are named meaningfully and consistently.
 - High coupling code blocks are adjacent to each other.
 - Errors are handled and exposed to users beautifully.


### PR DESCRIPTION
Joyent (creator of Node.js) has great resource pages about production practices when using Node.js. Unfortunately not many people read it... https://www.joyent.com/node-js/production

Maybe a good idea to add it to our criteria?

Goals for this change:

- Promote good practices for using Node.js in production.
- Educate candidates about Node.js production practices, in case they don’t have much experience in Node.js backend programming.