### PR TITLE
Add link to OWASP Top 10 - 2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The language choices are English, French, German, Japanese, Chinese, Korean, and
 
 You will be judged by the following criteria.
 - Functionality is correct with respect to the specifications.
-- Good security principles are followed.
+- Good security principles are followed. Please refer to [OWASP Top 10 2017](https://www.owasp.org/images/7/72/OWASP_Top_10-2017_%28en%29.pdf.pdf) to learn about the most important security considerations.
 - Good software engineering principles are followed, for example, [SOLID principles](https://en.wikipedia.org/wiki/SOLID).
 - Identifiers are named meaningfully and consistently.
 - High coupling code blocks are adjacent to each other.


### PR DESCRIPTION
Goals of this change:

- Raise awareness and promote security best practices.
- Educate the candidates in case they don’t know about the security best practices yet.